### PR TITLE
move env to its own package

### DIFF
--- a/packages/env/.env.template
+++ b/packages/env/.env.template
@@ -1,0 +1,3 @@
+coinmarketcap=""
+github=""
+port=9876

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "@blueserver/env",
+	"type": "module",
+	"scripts": {
+		"#todo": "lets wireit this command below",
+		"build": "tsc --pretty"
+	},
+	"exports": {
+		".": {
+			"import": "./lib/index.js",
+			"types": "./lib/index.d.ts"
+		}
+	}
+}

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,0 +1,19 @@
+import {DotEnvKeys} from '@blueserver/types';
+import dotenv from 'dotenv';
+import pathlib from 'path';
+import {fileURLToPath} from 'url';
+
+const __dirname = pathlib.dirname(fileURLToPath(import.meta.url));
+
+const _env = dotenv.config({
+	path: pathlib.join(__dirname, '..', '.env'),
+}).parsed as unknown as DotEnvKeys | undefined;
+
+// Required to exit the program nicely
+// and remove undefined errors further in the code.
+if (_env === undefined) {
+	console.log('env vars not found');
+	process.exit(0);
+}
+
+export const env = _env as DotEnvKeys;

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"compilerOptions": {
+		"module": "ES2022",
+		"target": "ES2022",
+		"moduleResolution": "nodenext",
+		"rootDir": "src",
+		"outDir": "lib",
+		"allowSyntheticDefaultImports": true
+	}
+}


### PR DESCRIPTION
Moving envs to its own package so we can have a global place.
So now external projects can use `@blueserver/env`